### PR TITLE
various: change "other" group to "brew"

### DIFF
--- a/.tfvars
+++ b/.tfvars
@@ -22,7 +22,7 @@ teams = {
     "BrewSponsorsBot",
   ],
   maintainers = {
-    other = [
+    brew = [
       "apainintheneck",
       "dduugg"
     ]

--- a/aws/iam-sso.tf
+++ b/aws/iam-sso.tf
@@ -52,14 +52,6 @@ resource "aws_identitystore_group_membership" "security" {
   member_id         = aws_identitystore_user.main[each.key].user_id
 }
 
-resource "aws_identitystore_group_membership" "analytics" {
-  for_each = nonsensitive(var.teams.Analytics)
-
-  identity_store_id = tolist(data.aws_ssoadmin_instances.main.identity_store_ids)[0]
-  group_id          = aws_identitystore_group.group["Analytics"].group_id
-  member_id         = aws_identitystore_user.main[each.key].user_id
-}
-
 resource "aws_ssoadmin_permission_set" "OpsAccess" {
   name         = "OpsAccess"
   description  = "Access for Ops"

--- a/github/groups.tf
+++ b/github/groups.tf
@@ -21,7 +21,7 @@ resource "github_team" "maintainers" {
   privacy        = "closed"
   parent_team_id = github_team.main["maintainers"].id
 
-  for_each = { for team in keys(var.teams.maintainers) : team => team if !contains(["other"], team) }
+  for_each = { for team in keys(var.teams.maintainers) : team => team if !contains(["brew"], team) }
 
   lifecycle {
     ignore_changes = [description]
@@ -29,7 +29,7 @@ resource "github_team" "maintainers" {
 }
 
 resource "github_team_membership" "maintainer_membership" {
-  for_each = toset(var.teams.maintainers.other)
+  for_each = toset(var.teams.maintainers.brew)
   team_id  = github_team.main["maintainers"].id
   username = each.key
   role     = contains(var.admins, each.key) ? "maintainer" : "member"

--- a/github/vars.tf
+++ b/github/vars.tf
@@ -5,7 +5,7 @@ variable "teams" {
     bots     = list(string)
     ops      = list(string)
     maintainers = object({
-      other = list(string)
+      brew = list(string)
       cask  = list(string)
       core  = list(string)
       tsc   = list(string)

--- a/import.tf
+++ b/import.tf
@@ -5,7 +5,7 @@ import {
 }
 
 import {
-  for_each = toset(var.teams.maintainers.other)
+  for_each = toset(var.teams.maintainers.brew)
   to       = module.github.github_team_membership.maintainer_membership[each.key]
   id       = "152937:${each.key}"
 }
@@ -31,7 +31,7 @@ import {
 }
 
 import {
-  for_each = { for team in keys(var.teams.maintainers) : team => team if !contains(["other"], team) }
+  for_each = { for team in keys(var.teams.maintainers) : team => team if !contains(["brew"], team) }
   to       = module.github.github_team.maintainers[each.key]
   id       = replace(each.key, "_", "-")
 }

--- a/vars.tf
+++ b/vars.tf
@@ -5,7 +5,7 @@ variable "teams" {
     ops      = list(string)
     bots     = list(string)
     maintainers = object({
-      other = list(string)
+      brew = list(string)
       cask  = list(string)
       core  = list(string)
       tsc   = list(string)


### PR DESCRIPTION
This PR changes the "other" group to "brew" since that's the only other main repo. This also attempts to fix CI failure by removing the Analytics group, since we are no longer using that.