### PR TITLE
import: remove already imported role

### DIFF
--- a/import.tf
+++ b/import.tf
@@ -45,8 +45,3 @@ import {
   to = module.aws.aws_iam_openid_connect_provider.github_actions
   id = "arn:aws:iam::765021812025:oidc-provider/token.actions.githubusercontent.com"
 }
-
-import {
-  to = module.aws.aws_iam_role.github_tf
-  id = "GitHubActionsS3Role"
-}


### PR DESCRIPTION
In #34 I introduced a change in the role name but forgot to update it in import.tf
As the name changed, and it's already imported, better just remove it now