### PR TITLE
roles: use aws_iam_role_policy_attachment

### DIFF
--- a/aws/roles.tf
+++ b/aws/roles.tf
@@ -79,8 +79,14 @@ resource "aws_iam_role" "github_tf" {
     ]
     Version = "2012-10-17"
   })
-  managed_policy_arns = [
-    "arn:aws:iam::aws:policy/AdministratorAccess",
-    aws_iam_policy.opentofu_policy.arn
-  ]
+}
+
+resource "aws_iam_role_policy_attachment" "github_tf_opentofu_policy_attachment" {
+  role       = aws_iam_role.github_tf.name
+  policy_arn = aws_iam_policy.opentofu_policy.arn
+}
+
+resource "aws_iam_role_policy_attachment" "github_tf_administrator_policy_attachment" {
+  role       = aws_iam_role.github_tf.name
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }


### PR DESCRIPTION
Fixes:
Warning: Argument is deprecated

  with module.aws.aws_iam_role.github_tf,
  on aws/roles.tf line 82, in resource "aws_iam_role" "github_tf":
  82:   managed_policy_arns = [
  83:     "arn:aws:iam::aws:policy/AdministratorAccess",
  84:     aws_iam_policy.opentofu_policy.arn
  85:   ]

managed_policy_arns is deprecated. Use the aws_iam_role_policy_attachment resource instead. If Terraform should exclusively manage all managed policy attachments (the current behavior of this argument), use the aws_iam_role_policy_attachments_exclusive resource as well.

--

I could have used aws_iam_role_policy_attachments_exclusive but I'm unsure we should make that policy exlcusive for the role. As we do not have that many policies / roles yet, I think we can leave it as-is.