### PR TITLE
github role: remove admin rights

### DIFF
--- a/aws/roles.tf
+++ b/aws/roles.tf
@@ -85,8 +85,3 @@ resource "aws_iam_role_policy_attachment" "github_tf_opentofu_policy_attachment"
   role       = aws_iam_role.github_tf.name
   policy_arn = aws_iam_policy.opentofu_policy.arn
 }
-
-resource "aws_iam_role_policy_attachment" "github_tf_administrator_policy_attachment" {
-  role       = aws_iam_role.github_tf.name
-  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
-}


### PR DESCRIPTION
In theory now that the attached policy (opentofu_policy) has enough permissions (iam, identitystore), we do not need full admin right anymore