### PR TITLE
roles: add role to be able to push to ECR from GitHub

### DIFF
--- a/aws/roles.tf
+++ b/aws/roles.tf
@@ -87,3 +87,62 @@ resource "aws_iam_role_policy_attachment" "github_tf_opentofu_policy_attachment"
   role       = aws_iam_role.github_tf.name
   policy_arn = aws_iam_policy.opentofu_policy.arn
 }
+
+data "aws_iam_policy_document" "ecr_policy_document" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:GetRepositoryPolicy",
+      "ecr:DescribeRepositories",
+      "ecr:ListImages",
+      "ecr:DescribeImages",
+      "ecr:BatchGetImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload",
+      "ecr:PutImage"
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "ecr_policy" {
+  name        = "ECRPushPolicy"
+  path        = "/"
+  description = "Policy to allow push to ECR"
+
+  policy = data.aws_iam_policy_document.ecr_policy_document.json
+}
+
+resource "aws_iam_role" "github_ecr_push_role" {
+  name        = "GithubActionsRoleECRPush"
+  description = "Allow GitHub actions to push to ECR"
+  assume_role_policy = jsonencode({
+    Statement = [
+      {
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Effect = "Allow"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:Homebrew/ci-orchestrator:*"
+          }
+        }
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github_actions.arn
+        }
+      }
+    ]
+    Version = "2012-10-17"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "github_ecr_policy_attachment" {
+  role       = aws_iam_role.github_ecr_push_role.name
+  policy_arn = aws_iam_policy.ecr_policy.arn
+}


### PR DESCRIPTION
This adds a new role that can be used to push the orchestrator docker image from the orchestrator repo to the ECR repo. I think I have added all the necessary policies for that action (I copied the list from the AWS doc)